### PR TITLE
Adjusted for breaking change in v11.7

### DIFF
--- a/RemoveAlertMaintenance/RemoveAlertMaintenance.ps1
+++ b/RemoveAlertMaintenance/RemoveAlertMaintenance.ps1
@@ -38,21 +38,43 @@ If ($MaintenanceId -eq "")
        }
 }
 
-$Request = '{
-  "context": {
-       "callerReference": "AzureDevOps",
-       "environmentSettings": {
-         "id": "' + $BizTalk360EnvironmentId + '"
-       }
-  },
-  "maintenanceId": "' + $MaintenanceId + '",
-  "comment": "BizTalk Deploy"
+## Between BizTalk360 11.6 and 11.7 a breaking change was done in the API
+if ([Version]$BizTalk360Version -ge [Version]'11.7')
+{
+    $Request = '{
+    "environmentMaintenances": [
+        {
+            "maintenanceId": "' + $MaintenanceId + '",
+            "environmentIds": [
+                "' + $BizTalk360EnvironmentId + '"
+            ]
+        }
+    ],
+    "context": {
+        "callerReference": "AzureDevOps",
+        "environmentSettings": {
+            "id": "' + $BizTalk360EnvironmentId + '"
+        }
+    },
+    "comment": "BizTalk Deploy"
 }'
-
+}
+else
+{
+    $Request = '{
+      "context": {
+          "callerReference": "AzureDevOps",
+          "environmentSettings": {
+            "id": "' + $BizTalk360EnvironmentId + '"
+          }
+      },
+      "maintenanceId": "' + $MaintenanceId + '",
+      "comment": "BizTalk Deploy"
+    }'
+}
 Write-Host $Request
 
 $ResponseSet = Invoke-RestMethod -Uri "$BizTalk360ServerUrl/biztalk360/Services.REST/AlertService.svc/$StopOperation" -Method Post -ContentType "application/json" -Body $Request -UseDefaultCredentials
-$ResponseSet | out-string
 
 If ($ResponseSet.success)
 {

--- a/RemoveAlertMaintenance/RemoveAlertMaintenance.ps1
+++ b/RemoveAlertMaintenance/RemoveAlertMaintenance.ps1
@@ -10,6 +10,8 @@ param(
     [string]$MaintenanceId = ""
 )
 
+$MaintenanceLabel = "DevOps deployment of {0}, {1}, attempt {2}" -f $Env:BUILD_DEFINITIONNAME,$Env:BUILD_BUILDNUMBER,$Env:SYSTEM_JOBATTEMPT
+
 $ResponseSet = Invoke-RestMethod -Uri "$BizTalk360ServerUrl/BizTalk360/Services.REST/AdminService.svc/GetBizTalk360Info" -Method Get -UseDefaultCredentials
 $ResponseSet | out-string
 $BizTalk360Version = $ResponseSet.bizTalk360Info.biztalk360Version
@@ -30,7 +32,7 @@ If ($MaintenanceId -eq "")
        $ResponseSet = Invoke-RestMethod -Uri "$BizTalk360ServerUrl/biztalk360/Services.REST/AlertService.svc/GetAlertMaintenance?environmentId=$BizTalk360EnvironmentId" -Method Get -UseDefaultCredentials
 	   $ResponseSet | out-string
 
-       $maintenance = @($ResponseSet.alertMaintenances | where { $_.comment -eq "BizTalk Deploy" })
+       $maintenance = @($ResponseSet.alertMaintenances | where { $_.comment -eq "$MaintenanceLabel" })
 
        If ($maintenance.Count -gt 0)
        {
@@ -51,25 +53,25 @@ if ([Version]$BizTalk360Version -ge [Version]'11.7')
         }
     ],
     "context": {
-        "callerReference": "AzureDevOps",
+        "callerReference": "' + $MaintenanceLabel + '",
         "environmentSettings": {
             "id": "' + $BizTalk360EnvironmentId + '"
         }
     },
-    "comment": "BizTalk Deploy"
+    "comment": "' + $MaintenanceLabel + '"
 }'
 }
 else
 {
     $Request = '{
       "context": {
-          "callerReference": "AzureDevOps",
+          "callerReference": "' + $MaintenanceLabel + '",
           "environmentSettings": {
             "id": "' + $BizTalk360EnvironmentId + '"
           }
       },
       "maintenanceId": "' + $MaintenanceId + '",
-      "comment": "BizTalk Deploy"
+      "comment": "' + $MaintenanceLabel + '"
     }'
 }
 Write-Host $Request

--- a/RemoveAlertMaintenance/RemoveAlertMaintenance.ps1
+++ b/RemoveAlertMaintenance/RemoveAlertMaintenance.ps1
@@ -10,7 +10,7 @@ param(
     [string]$MaintenanceId = ""
 )
 
-$MaintenanceLabel = "DevOps deployment of {0}, {1}, attempt {2}" -f $Env:BUILD_DEFINITIONNAME,$Env:BUILD_BUILDNUMBER,$Env:SYSTEM_JOBATTEMPT
+$MaintenanceLabel = "DevOps deployment of {0}, {1}, attempt {2}" -f $Env:BUILD_DEFINITIONNAME,$Env:BUILD_BUILDNUMBER,$Env:SYSTEM_STAGEATTEMPT
 
 $ResponseSet = Invoke-RestMethod -Uri "$BizTalk360ServerUrl/BizTalk360/Services.REST/AdminService.svc/GetBizTalk360Info" -Method Get -UseDefaultCredentials
 $ResponseSet | out-string

--- a/RemoveAlertMaintenance/task.json
+++ b/RemoveAlertMaintenance/task.json
@@ -9,8 +9,8 @@
 	"author": "Martin Peters",
 	"version": {
 		"Major": 2,
-		"Minor": 0,
-		"Patch": 5
+		"Minor": 1,
+		"Patch": 0
 	},
 	"instanceNameFormat": "Start BizTalk360 alerts after maintenance",
 	"inputs": [

--- a/SetAlertMaintenance/SetAlertMaintenance.ps1
+++ b/SetAlertMaintenance/SetAlertMaintenance.ps1
@@ -12,6 +12,7 @@ $DateTime = Get-Date
 ##$DateTime = $DateTime.ToUniversalTime()
 
 $ResponseSet = Invoke-RestMethod -Uri "$BizTalk360ServerUrl/BizTalk360/Services.REST/AdminService.svc/GetBizTalk360Info" -Method Get -UseDefaultCredentials
+$ResponseSet | out-string
 $BizTalk360Version = $ResponseSet.bizTalk360Info.biztalk360Version
 
 ## Between BizTalk360 11.6 and 11.7 a breaking change was done in the API

--- a/SetAlertMaintenance/SetAlertMaintenance.ps1
+++ b/SetAlertMaintenance/SetAlertMaintenance.ps1
@@ -36,7 +36,7 @@ if ([Version]$BizTalk360Version -ge [Version]'11.7')
             "recurrenceEndDate": "' + $DateTime.AddHours(1).ToString("yyyyMMdd") + '",
             "recurrenceStartTime": "' + $DateTime.ToString("HHmmss") + '",
             "recurrenceEndTime": "' + $DateTime.AddHours(1).ToString("HHmmss") + '",
-            "isImmediate": false
+            "isImmediate": true
         },
         "environmentIds": [
           "' + $BizTalk360EnvironmentId + '"

--- a/SetAlertMaintenance/SetAlertMaintenance.ps1
+++ b/SetAlertMaintenance/SetAlertMaintenance.ps1
@@ -7,6 +7,8 @@ param(
     [string]$BizTalk360ServerUrl
 )
 
+$MaintenanceLabel = "DevOps deployment of {0}, {1}, attempt {2}" -f $Env:BUILD_DEFINITIONNAME,$Env:BUILD_BUILDNUMBER,$Env:SYSTEM_JOBATTEMPT
+
 $DateTime = Get-Date
 ##Don't know why it is localtime on 1 server and UTC on another.
 ##$DateTime = $DateTime.ToUniversalTime()
@@ -20,18 +22,18 @@ if ([Version]$BizTalk360Version -ge [Version]'11.7')
 {
     $Request = '{
       "context": {
-        "callerReference": "AzureDevOps",
+        "callerReference": "' + $MaintenanceLabel + '",
         "environmentSettings": {
           "id": "' + $BizTalk360EnvironmentId + '"
         }
       },
       "alertMaintenance": {
-        "name": "BizTalk Deploy",
-        "comment": "BizTalk Deploy",
+        "name": "' + $MaintenanceLabel + '",
+        "comment": "' + $MaintenanceLabel + '",
         "maintenanceStartTime": "' + $DateTime.ToString("yyyy-MM-ddTHH:mm:ss.000") + '",
         "expiryDateTime": "' + $DateTime.AddHours(1).ToString("yyyy-MM-ddTHH:mm:ss.000") + '",
         "isOneTimeSchedule" : true,
-        "summary": "BizTalk Deploy",
+        "summary": "' + $MaintenanceLabel + '",
         "scheduleConfiguration": {
             "recurrenceStartDate": "' + $DateTime.ToString("yyyyMMdd") + '",
             "recurrenceEndDate": "' + $DateTime.AddHours(1).ToString("yyyyMMdd") + '",
@@ -50,14 +52,14 @@ elseif ([Version]$BizTalk360Version -ge [Version]'9.1')
 {
     $Request = '{
       "context": {
-        "callerReference": "AzureDevOps",
+        "callerReference": "' + $MaintenanceLabel + '",
         "environmentSettings": {
           "id": "' + $BizTalk360EnvironmentId + '"
         }
       },
       "alertMaintenance": {
-        "name": "BizTalk Deploy",
-        "comment": "BizTalk Deploy",
+        "name": "' + $MaintenanceLabel + '",
+        "comment": "' + $MaintenanceLabel + '",
         "maintenanceStartTime": "' + $DateTime.ToString("yyyy-MM-ddTHH:mm:ss.000") + '",
         "expiryDateTime": "' + $DateTime.AddHours(1).ToString("yyyy-MM-ddTHH:mm:ss.000") + '",
         "isOneTimeSchedule" : true,
@@ -76,13 +78,13 @@ else
 {
     $Request = '{
       "context": {
-        "callerReference": "AzureDevOps",
+        "callerReference": "' + $MaintenanceLabel + '",
         "environmentSettings": {
           "id": "' + $BizTalk360EnvironmentId + '"
         }
       },
       "alertMaintenance": {
-        "comment": "BizTalk Deploy",
+        "comment": "' + $MaintenanceLabel + '",
         "maintenanceStartTime": "' + $DateTime.ToString("yyyy-MM-ddTHH:mm:ss.000") + '",
         "maintenanceTimeUnit": 0,
         "maintenanceTimeLength": 60,

--- a/SetAlertMaintenance/SetAlertMaintenance.ps1
+++ b/SetAlertMaintenance/SetAlertMaintenance.ps1
@@ -15,8 +15,38 @@ $ResponseSet = Invoke-RestMethod -Uri "$BizTalk360ServerUrl/BizTalk360/Services.
 $ResponseSet | out-string
 $BizTalk360Version = $ResponseSet.bizTalk360Info.biztalk360Version
 
+## Between BizTalk360 11.6 and 11.7 a breaking change was done in the API
+if ([Version]$BizTalk360Version -ge [Version]'11.7')
+{
+    $Request = '{
+      "context": {
+        "callerReference": "AzureDevOps",
+        "environmentSettings": {
+          "id": "' + $BizTalk360EnvironmentId + '"
+        }
+      },
+      "alertMaintenance": {
+        "name": "BizTalk Deploy",
+        "comment": "BizTalk Deploy",
+        "maintenanceStartTime": "' + $DateTime.ToString("yyyy-MM-ddTHH:mm:ss.000") + '",
+        "expiryDateTime": "' + $DateTime.AddHours(1).ToString("yyyy-MM-ddTHH:mm:ss.000") + '",
+        "isOneTimeSchedule" : true,
+        "summary": "BizTalk Deploy",
+        "scheduleConfiguration": {
+            "recurrenceStartDate": "' + $DateTime.ToString("yyyyMMdd") + '",
+            "recurrenceEndDate": "' + $DateTime.AddHours(1).ToString("yyyyMMdd") + '",
+            "recurrenceStartTime": "' + $DateTime.ToString("HHmmss") + '",
+            "recurrenceEndTime": "' + $DateTime.AddHours(1).ToString("HHmmss") + '",
+            "isImmediate": false
+        },
+        "environmentIds": [
+          "' + $BizTalk360EnvironmentId + '"
+        ]
+      }
+    }'
+}
 ## Between BizTalk360 9.0 and 9.1 a breaking change was done in the API
-if ([Version]$BizTalk360Version -ge [Version]'9.1')
+elseif ([Version]$BizTalk360Version -ge [Version]'9.1')
 {
     $Request = '{
       "context": {

--- a/SetAlertMaintenance/SetAlertMaintenance.ps1
+++ b/SetAlertMaintenance/SetAlertMaintenance.ps1
@@ -7,7 +7,7 @@ param(
     [string]$BizTalk360ServerUrl
 )
 
-$MaintenanceLabel = "DevOps deployment of {0}, {1}, attempt {2}" -f $Env:BUILD_DEFINITIONNAME,$Env:BUILD_BUILDNUMBER,$Env:SYSTEM_JOBATTEMPT
+$MaintenanceLabel = "DevOps deployment of {0}, {1}, attempt {2}" -f $Env:BUILD_DEFINITIONNAME,$Env:BUILD_BUILDNUMBER,$Env:SYSTEM_STAGEATTEMPT
 
 $DateTime = Get-Date
 ##Don't know why it is localtime on 1 server and UTC on another.

--- a/SetAlertMaintenance/SetAlertMaintenance.ps1
+++ b/SetAlertMaintenance/SetAlertMaintenance.ps1
@@ -12,7 +12,6 @@ $DateTime = Get-Date
 ##$DateTime = $DateTime.ToUniversalTime()
 
 $ResponseSet = Invoke-RestMethod -Uri "$BizTalk360ServerUrl/BizTalk360/Services.REST/AdminService.svc/GetBizTalk360Info" -Method Get -UseDefaultCredentials
-$ResponseSet | out-string
 $BizTalk360Version = $ResponseSet.bizTalk360Info.biztalk360Version
 
 ## Between BizTalk360 11.6 and 11.7 a breaking change was done in the API

--- a/SetAlertMaintenance/task.json
+++ b/SetAlertMaintenance/task.json
@@ -9,8 +9,8 @@
 	"author": "Martin Peters",
 	"version": {
 		"Major": 2,
-		"Minor": 0,
-		"Patch": 5
+		"Minor": 1,
+		"Patch": 0
 	},
 	"instanceNameFormat": "Stop BizTalk360 alerts for maintenance",
 	"inputs": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "biztalk360-maintenance-tasks",
     "name": "BizTalk360 Maintenance Tasks",
-    "version": "1.2.2",
+    "version": "1.3.0",
     "publisher": "twinpiloot",
 	  "public": true,
     "targets": [


### PR DESCRIPTION
Proposed solution for #4 

- Adjusted request body for BizTalk360 API version 11.7 onwards. From this version, alert maintenances can be set for multiple environments. This PR applies this to both `SetAlertMaintenance` and `RemoveAlertMaintenance`
- set the `isImmediate` flag to `true`, because there was a perceived delay in the maintenance becoming active, even when the maintenanceStartTime had already past
- Upon stopping an alert, it remains present in BizTalk360 until is effectively removed (note that with the introduction of BizTalk360 API version 9.1, the extension had moved from calling the `RemoveAlertMaintenance` to `StopAlertMaintenance`). Upon attempting to create another maintenance with the same name, BizTalk360 does not show that new maintenance, and from the UI it appears as if there is no new maintenance created nor in effect, although the SetAlertMaintenance API method does return a normal response including a new `maintenanceId`. To mitigate this, the new maintenance name is set dynamically, using the pipeline name, the build number, and the stage attempt sequence number, which also improves clarity for the end-user in the BizTalk360 UI.